### PR TITLE
Entra connect sync health agent import required modules and check local machine certificates function

### DIFF
--- a/AADCHRep.ps1
+++ b/AADCHRep.ps1
@@ -978,9 +978,9 @@ Function collectLogs{
 # Check local machine certs
 #================================================================#
 
-function checkExpiredCertificates {
-    Write-Host 'Checking expired local machine certificates ' -ForegroundColor $outputColor
-    $SubHeader = "<h3>TLS 1.2 registry values</h3>"
+function checkLocalMachineCertificates {
+    Write-Host 'Checking local machine certificates' -ForegroundColor $outputColor
+    $SubHeader = "<h3>Expired or near-expiry local machine certificates</h3>"
     $global:HTMLBody += $SubHeader
    
     
@@ -1001,13 +1001,13 @@ function checkExpiredCertificates {
 
         if($certs.count -gt 0){
             # Show Certs count
-            $global:HTMLBody += "<h3>$($certs.count) expired or about to expire in $expirationDays days.</h3>"
+            $global:HTMLBody += "<h3>$($certs.count) LocalMachine certificates expired or about to expire in $expirationDays days.</h3>"
             $global:HTMLBody += $certs | ConvertTo-Html -Fragment
 
         } 
         else {
-            Write-host "No certificates expired or about to expire in $expirationDays days."
-            $global:HTMLBody += "No certificates expired or about to expire in $expirationDays days."
+            #Write-host "No certificates expired or about to expire in $expirationDays days."
+            $global:HTMLBody += "No LocalMachine certificates expired or about to expire in $expirationDays days."
         }
 
     }
@@ -1131,7 +1131,7 @@ Write-Host ''
     
     servicesInfo
 
-    checkExpiredCertificates
+    checkLocalMachineCertificates
 
     generateReport
 

--- a/AADCHRep.ps1
+++ b/AADCHRep.ps1
@@ -1131,7 +1131,9 @@ Write-Host ''
     
     servicesInfo
 
-    generateReport	
+    checkExpiredCertificates
+
+    generateReport
 
 Write-Host ''
 Write-Host '============================================='


### PR DESCRIPTION
1. Made cosmetic changes to use full syntax commands rather than their aliases such as Select-Object rather than Select, and so on.
2. Added `Import-Module "C:\Program Files\Microsoft Azure AD Connect Health agent\Modules\AdHealthConfiguration\AdHealthConfiguration.psd1"` to the `connectivityTest` function to avoid the possibility of the function failing due to the test connectivity commands not found. 
3. Added a new function checkLocalMachineCertificates to check Local Machine certificates that are expired or about to be expired as these would cause issues with registering the health agent and/or testing the connectivity